### PR TITLE
remove warnings

### DIFF
--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
@@ -109,32 +109,42 @@ def create_indivim_menagem(temporary_store = None, year = None):
     # création de variables#
     ########################
 
+
+  #  print indivim
 #   actrec : activité recodée comme preconisé par l'INSEE p84 du guide utilisateur
     indivim["actrec"] = numpy.nan
     # Attention : Q: pas de 6 ?!! A : Non pas de 6, la variable recodée de l'INSEE (voit p84 du guide methodo), ici \
     # la même nomenclatue à été adopée
 
     # 3: contrat a durée déterminée
-    indivim['actrec'][indivim.acteu == 1] = 3
+   # indivim['actrec'][indivim.acteu == 1] = 3
+    indivim.loc[indivim.acteu == 1,'actrec'] = 3
     # 8 : femme (homme) au foyer, autre inactif
-    indivim['actrec'][indivim.acteu == 3] = 8
+   # indivim['actrec'][indivim.acteu == 3] = 8
+    indivim.loc[indivim.acteu == 3,'actrec'] = 8
     # 1 : actif occupé non salarié
     filter1 = (indivim.acteu == 1) & (indivim.stc.isin([1, 3]))  # actifs occupés non salariés à son compte ou pour un
-    indivim["actrec"][filter1] = 1                                # membre de sa famille
+    #indivim["actrec"][filter1] = 1                                # membre de sa famille
+    indivim.loc[filter1,'actrec'] = 1
     # 2 : salarié pour une durée non limitée
     filter2 = (indivim.acteu == 1) & (((indivim.stc == 2) & (indivim.contra == 1)) | (indivim.titc == 2))
-    indivim['actrec'][filter2] = 2
+ #   indivim['actrec'][filter2] = 2
+    indivim.loc[filter2,'actrec'] = 2
     # 4 : au chomage
     filter4 = (indivim.acteu == 2) | ((indivim.acteu == 3) & (indivim.mrec == 1))
-    indivim['actrec'][filter4] = 4
+   # indivim['actrec'][filter4] = 4
+    indivim.loc[filter4,'actrec'] = 4
     # 5 : élève étudiant , stagiaire non rémunéré
     filter5 = (indivim.acteu == 3) & ((indivim.forter == 2) | (indivim.rstg == 1))
-    indivim['actrec'][filter5] = 5
+   # indivim['actrec'][filter5] = 5
+    indivim.loc[filter5,'actrec'] = 5
     # 7 : retraité, préretraité, retiré des affaires unchecked
     filter7 = (indivim.acteu == 3) & ((indivim.retrai == 1) | (indivim.retrai == 2))
-    indivim['actrec'][filter7] = 7
+    #indivim['actrec'][filter7] = 7
+    indivim.loc[filter7,'actrec'] = 7
     # 9 : probablement enfants de - de 16 ans TODO: check that fact in database and questionnaire
-    indivim['actrec'][indivim.acteu == 0] = 9
+    #indivim['actrec'][indivim.acteu == 0] = 9
+    indivim.loc[indivim.acteu == 0,'actrec'] = 9
 
     indivim.actrec = indivim.actrec.astype("int8")
     assert_dtype(indivim.actrec, "int8")
@@ -219,7 +229,7 @@ def create_enfants_a_naitre(temporary_store = None, year = None):
     # TODO: minimal dtype TODO: shoudln't be here
     for var in individual_vars:
         assert_dtype(enfants_a_naitre[var], 'float')
-    del eeccmp1, eeccmp2, eeccmp3, individual_vars, tmp  #TODO: Adrien: me fait planter python
+    del eeccmp1, eeccmp2, eeccmp3, individual_vars, tmp
     gc.collect()
 
     # création de variables
@@ -229,7 +239,7 @@ def create_enfants_a_naitre(temporary_store = None, year = None):
     enfants_a_naitre['year'] = year
     enfants_a_naitre.year = enfants_a_naitre.year.astype("float32")  # TODO: should be an integer but NaN are present
     enfants_a_naitre['agepf'] = enfants_a_naitre.year - enfants_a_naitre.naia
-    enfants_a_naitre['agepf'][enfants_a_naitre.naim >= 7] -= 1
+    enfants_a_naitre.loc[enfants_a_naitre.naim >= 7,'agepf'] -= 1
     enfants_a_naitre['actrec'] = 9
     enfants_a_naitre['quelfic'] = 'ENF_NN'
     enfants_a_naitre['persfip'] = ""
@@ -248,7 +258,7 @@ def create_enfants_a_naitre(temporary_store = None, year = None):
         ].copy()
 
     temporary_store["enfants_a_naitre_{}".format(year)] = enfants_a_naitre
-
+    
 
 if __name__ == '__main__':
     log.info('Entering 01_pre_proc')

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
@@ -114,36 +114,27 @@ def create_indivim_menagem(temporary_store = None, year = None):
 #   actrec : activité recodée comme preconisé par l'INSEE p84 du guide utilisateur
     indivim["actrec"] = numpy.nan
     # Attention : Q: pas de 6 ?!! A : Non pas de 6, la variable recodée de l'INSEE (voit p84 du guide methodo), ici \
-    # la même nomenclature à été adopée
-    
+    # la même nomenclature à été adopée    
     # 3: contrat a durée déterminée
-   # indivim['actrec'][indivim.acteu == 1] = 3
     indivim.actrec.loc[indivim.acteu == 1] = 3
     # 8 : femme (homme) au foyer, autre inactif
-   # indivim['actrec'][indivim.acteu == 3] = 8
     indivim.actrec.loc[indivim.acteu == 3] = 8
     # 1 : actif occupé non salarié
     filter1 = (indivim.acteu == 1) & (indivim.stc.isin([1, 3]))  # actifs occupés non salariés à son compte ou pour un
-    #indivim["actrec"][filter1] = 1                                # membre de sa famille
-    indivim.actrec.loc[filter1] = 1
+    indivim.actrec.loc[filter1] = 1                              # membre de sa famille
     # 2 : salarié pour une durée non limitée
     filter2 = (indivim.acteu == 1) & (((indivim.stc == 2) & (indivim.contra == 1)) | (indivim.titc == 2))
- #   indivim['actrec'][filter2] = 2
     indivim.actrec.loc[filter2] = 2
     # 4 : au chomage
     filter4 = (indivim.acteu == 2) | ((indivim.acteu == 3) & (indivim.mrec == 1))
-   # indivim['actrec'][filter4] = 4
     indivim.actrec.loc[filter4] = 4
     # 5 : élève étudiant , stagiaire non rémunéré
     filter5 = (indivim.acteu == 3) & ((indivim.forter == 2) | (indivim.rstg == 1))
-   # indivim['actrec'][filter5] = 5
     indivim.actrec.loc[filter5] = 5
     # 7 : retraité, préretraité, retiré des affaires unchecked
     filter7 = (indivim.acteu == 3) & ((indivim.retrai == 1) | (indivim.retrai == 2))
-    #indivim['actrec'][filter7] = 7
     indivim.actrec.loc[filter7] = 7
     # 9 : probablement enfants de - de 16 ans TODO: check that fact in database and questionnaire
-    #indivim['actrec'][indivim.acteu == 0] = 9
     indivim.actrec.loc[indivim.acteu == 0] = 9
 
     indivim.actrec = indivim.actrec.astype("int8")
@@ -259,7 +250,6 @@ def create_enfants_a_naitre(temporary_store = None, year = None):
 
     temporary_store["enfants_a_naitre_{}".format(year)] = enfants_a_naitre
     
-
 if __name__ == '__main__':
     log.info('Entering 01_pre_proc')
     import sys

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
@@ -114,8 +114,8 @@ def create_indivim_menagem(temporary_store = None, year = None):
 #   actrec : activité recodée comme preconisé par l'INSEE p84 du guide utilisateur
     indivim["actrec"] = numpy.nan
     # Attention : Q: pas de 6 ?!! A : Non pas de 6, la variable recodée de l'INSEE (voit p84 du guide methodo), ici \
-    # la même nomenclatue à été adopée
-
+    # la même nomenclature à été adopée
+    
     # 3: contrat a durée déterminée
    # indivim['actrec'][indivim.acteu == 1] = 3
     indivim.actrec.loc[indivim.acteu == 1] = 3

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_01_pre_processing.py
@@ -118,33 +118,33 @@ def create_indivim_menagem(temporary_store = None, year = None):
 
     # 3: contrat a durée déterminée
    # indivim['actrec'][indivim.acteu == 1] = 3
-    indivim.loc[indivim.acteu == 1,'actrec'] = 3
+    indivim.actrec.loc[indivim.acteu == 1] = 3
     # 8 : femme (homme) au foyer, autre inactif
    # indivim['actrec'][indivim.acteu == 3] = 8
-    indivim.loc[indivim.acteu == 3,'actrec'] = 8
+    indivim.actrec.loc[indivim.acteu == 3] = 8
     # 1 : actif occupé non salarié
     filter1 = (indivim.acteu == 1) & (indivim.stc.isin([1, 3]))  # actifs occupés non salariés à son compte ou pour un
     #indivim["actrec"][filter1] = 1                                # membre de sa famille
-    indivim.loc[filter1,'actrec'] = 1
+    indivim.actrec.loc[filter1] = 1
     # 2 : salarié pour une durée non limitée
     filter2 = (indivim.acteu == 1) & (((indivim.stc == 2) & (indivim.contra == 1)) | (indivim.titc == 2))
  #   indivim['actrec'][filter2] = 2
-    indivim.loc[filter2,'actrec'] = 2
+    indivim.actrec.loc[filter2] = 2
     # 4 : au chomage
     filter4 = (indivim.acteu == 2) | ((indivim.acteu == 3) & (indivim.mrec == 1))
    # indivim['actrec'][filter4] = 4
-    indivim.loc[filter4,'actrec'] = 4
+    indivim.actrec.loc[filter4] = 4
     # 5 : élève étudiant , stagiaire non rémunéré
     filter5 = (indivim.acteu == 3) & ((indivim.forter == 2) | (indivim.rstg == 1))
    # indivim['actrec'][filter5] = 5
-    indivim.loc[filter5,'actrec'] = 5
+    indivim.actrec.loc[filter5] = 5
     # 7 : retraité, préretraité, retiré des affaires unchecked
     filter7 = (indivim.acteu == 3) & ((indivim.retrai == 1) | (indivim.retrai == 2))
     #indivim['actrec'][filter7] = 7
-    indivim.loc[filter7,'actrec'] = 7
+    indivim.actrec.loc[filter7] = 7
     # 9 : probablement enfants de - de 16 ans TODO: check that fact in database and questionnaire
     #indivim['actrec'][indivim.acteu == 0] = 9
-    indivim.loc[indivim.acteu == 0,'actrec'] = 9
+    indivim.actrec.loc[indivim.acteu == 0] = 9
 
     indivim.actrec = indivim.actrec.astype("int8")
     assert_dtype(indivim.actrec, "int8")

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_04_famille.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_04_famille.py
@@ -553,7 +553,7 @@ def famille(temporary_store = None, year = None):
 
     famille['rang'] = famille.kid.astype('int')
     while any(famille[(famille.rang != 0)].duplicated(subset = ['rang', 'noifam'])):
-        famille.rang.loc[famille.rang != 0]+= famille[famille.rang != 0].copy().duplicated(
+        famille.rang.loc[famille.rang != 0] += famille[famille.rang != 0].copy().duplicated(
             subset = ["rang", 'noifam']).values
         log.info(u"nb de rangs différents : {}".format(len(set(famille.rang.values))))
 

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_04_famille.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_04_famille.py
@@ -553,8 +553,10 @@ def famille(temporary_store = None, year = None):
 
     famille['rang'] = famille.kid.astype('int')
     while any(famille[(famille.rang != 0)].duplicated(subset = ['rang', 'noifam'])):
-        famille["rang"][famille.rang != 0] += famille[famille.rang != 0].copy().duplicated(
+        famille.rang.loc[famille.rang != 0]+= famille[famille.rang != 0].copy().duplicated(
             subset = ["rang", 'noifam']).values
+#        famille.loc[famille.rang != 0,'rang'] += famille[famille.rang != 0].copy().duplicated(
+#            subset = ["rang", 'noifam']).values
         log.info(u"nb de rangs différents : {}".format(len(set(famille.rang.values))))
 
     log.info(u"    7.3 : création de la colonne quifam et troncature")

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_04_famille.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_04_famille.py
@@ -555,8 +555,6 @@ def famille(temporary_store = None, year = None):
     while any(famille[(famille.rang != 0)].duplicated(subset = ['rang', 'noifam'])):
         famille.rang.loc[famille.rang != 0]+= famille[famille.rang != 0].copy().duplicated(
             subset = ["rang", 'noifam']).values
-#        famille.loc[famille.rang != 0,'rang'] += famille[famille.rang != 0].copy().duplicated(
-#            subset = ["rang", 'noifam']).values
         log.info(u"nb de rangs différents : {}".format(len(set(famille.rang.values))))
 
     log.info(u"    7.3 : création de la colonne quifam et troncature")

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_05_foyer.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_05_foyer.py
@@ -396,18 +396,12 @@ def foyer_all(temporary_store = None, year = None):
     foy_ind.rename(columns = {"noindiv": "idfoy"}, inplace = True)
 
     print_id(foy_ind)
-#    foy_ind['quifoy'][foy_ind.quifoy == 'vous'] = 0
-#    foy_ind['quifoy'][foy_ind.quifoy == 'conj'] = 1
-#    foy_ind['quifoy'][foy_ind.quifoy == 'pac1'] = 2
-#    foy_ind['quifoy'][foy_ind.quifoy == 'pac2'] = 3
-#    foy_ind['quifoy'][foy_ind.quifoy == 'pac3'] = 4
-    
+
     foy_ind.quifoy.loc[foy_ind.quifoy == 'vous'] = 0
     foy_ind.quifoy.loc[foy_ind.quifoy == 'conj'] = 1
     foy_ind.quifoy.loc[foy_ind.quifoy == 'pac1'] = 2
     foy_ind.quifoy.loc[foy_ind.quifoy == 'pac2'] = 3
     foy_ind.quifoy.loc[foy_ind.quifoy == 'pac3'] = 4
-
 
     assert foy_ind.quifoy .isin(range(5)).all(), 'présence de valeurs aberrantes dans quifoy'
 

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_05_foyer.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_05_foyer.py
@@ -72,10 +72,10 @@ def sif(temporary_store = None, year = None):
     if year == 2009:
         old_sif = sif['sif'][sif['noindiv'] == 901803201].copy()
         new_sif = old_sif.str[0:59] + old_sif.str[60:] + "0"
-        sif['sif'][sif['noindiv'] == 901803201] = new_sif.values
-        old_sif = sif['sif'][sif['noindiv'] == 900872201]
+        sif.sif.loc[sif['noindiv'] == 901803201] = new_sif.values
+        old_sif = sif.sif.loc[sif['noindiv'] == 900872201]
         new_sif = old_sif.str[0:58] + " " + old_sif.str[58:]
-        sif['sif'][sif['noindiv'] == 900872201] = new_sif.values
+        sif.sif.loc[sif['noindiv'] == 900872201] = new_sif.values
         del old_sif, new_sif
 
     sif["rbg"] = sif["rbg"] * ((sif["tsrvbg"] == '+').astype(int) - (sif["tsrvbg"] == '-').astype(int))
@@ -84,7 +84,7 @@ def sif(temporary_store = None, year = None):
     # Converting marital status
     statmarit_dict = {"M": 1, "C": 2, "D": 3, "V": 4, "O": 5}
     for key, val in statmarit_dict.iteritems():
-        sif["statmarit"][sif.stamar == key] = val
+        sif.statmarit.loc[sif.stamar == key] = val
 
     sif["birthvous"] = sif.sif.str[5:9]
     sif["birthconj"] = sif.sif.str[10:14]
@@ -396,11 +396,18 @@ def foyer_all(temporary_store = None, year = None):
     foy_ind.rename(columns = {"noindiv": "idfoy"}, inplace = True)
 
     print_id(foy_ind)
-    foy_ind['quifoy'][foy_ind.quifoy == 'vous'] = 0
-    foy_ind['quifoy'][foy_ind.quifoy == 'conj'] = 1
-    foy_ind['quifoy'][foy_ind.quifoy == 'pac1'] = 2
-    foy_ind['quifoy'][foy_ind.quifoy == 'pac2'] = 3
-    foy_ind['quifoy'][foy_ind.quifoy == 'pac3'] = 4
+#    foy_ind['quifoy'][foy_ind.quifoy == 'vous'] = 0
+#    foy_ind['quifoy'][foy_ind.quifoy == 'conj'] = 1
+#    foy_ind['quifoy'][foy_ind.quifoy == 'pac1'] = 2
+#    foy_ind['quifoy'][foy_ind.quifoy == 'pac2'] = 3
+#    foy_ind['quifoy'][foy_ind.quifoy == 'pac3'] = 4
+    
+    foy_ind.quifoy.loc[foy_ind.quifoy == 'vous'] = 0
+    foy_ind.quifoy.loc[foy_ind.quifoy == 'conj'] = 1
+    foy_ind.quifoy.loc[foy_ind.quifoy == 'pac1'] = 2
+    foy_ind.quifoy.loc[foy_ind.quifoy == 'pac2'] = 3
+    foy_ind.quifoy.loc[foy_ind.quifoy == 'pac3'] = 4
+
 
     assert foy_ind.quifoy .isin(range(5)).all(), 'présence de valeurs aberrantes dans quifoy'
 

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_06_rebuild.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_06_rebuild.py
@@ -144,14 +144,14 @@ def create_totals(temporary_store = None, year = None):
     # assert indivi_fnd["idfoy"].duplicated().value_counts()[False] == len(indivi_fnd["idfoy"].values), "Duplicates remaining"
     assert len(indivi[indivi.duplicated(['noindiv'])]) == 0, "Doublons"
 
-    indivi.idfoy[fip_no_declar] = indivi_fnd.idfoy.copy()
+    indivi.idfoy.loc[fip_no_declar] = indivi_fnd.idfoy.copy()
     del indivi_fnd, fip_no_declar
 
     log.info(u"Etape 3 : Récupération des EE_NRT")
 
     nrt = indivi.quelfic == "EE_NRT"
     indivi.idfoy = where(nrt, indivi.idmen * 100 + indivi.noi, indivi.idfoy)
-    indivi.quifoy[nrt] = "vous"
+    indivi.quifoy.loc[nrt] = "vous"
     del nrt
 
     pref_or_cref = indivi.lpr.isin([1, 2])
@@ -266,13 +266,13 @@ def create_totals(temporary_store = None, year = None):
     indivi['age_en_mois'] = 12 * indivi.age + 12 - indivi.naim
 
     indivi["quimen"] = 0
-    indivi.quimen[indivi.lpr == 1] = 0
-    indivi.quimen[indivi.lpr == 2] = 1
-    indivi.quimen[indivi.lpr == 3] = 2
-    indivi.quimen[indivi.lpr == 4] = 3
+    indivi.quimen.loc[indivi.lpr == 1] = 0
+    indivi.quimen.loc[indivi.lpr == 2] = 1
+    indivi.quimen.loc[indivi.lpr == 3] = 2
+    indivi.quimen.loc[indivi.lpr == 4] = 3
     indivi['not_pr_cpr'] = None  # Create a new row
-    indivi.not_pr_cpr[indivi.lpr <= 2] = False
-    indivi.not_pr_cpr[indivi.lpr > 2] = True
+    indivi.not_pr_cpr.loc[indivi.lpr <= 2] = False
+    indivi.not_pr_cpr.loc[indivi.lpr > 2] = True
 
     assert indivi.not_pr_cpr.isin([True, False]).all()
 
@@ -355,33 +355,33 @@ def create_totals(temporary_store = None, year = None):
     log.info(u"Etape 6 : Création des variables descriptives")
     log.info(u"    6.1 : variable activité")
     indivi['activite'] = None
-    indivi['activite'][indivi.actrec <= 3] = 0
-    indivi['activite'][indivi.actrec == 4] = 1
-    indivi['activite'][indivi.actrec == 5] = 2
-    indivi['activite'][indivi.actrec == 7] = 3
-    indivi['activite'][indivi.actrec == 8] = 4
-    indivi['activite'][indivi.age <= 13] = 2  # ce sont en fait les actrec=9
+    indivi.activite.loc[indivi.actrec <= 3] = 0
+    indivi.activite.loc[indivi.actrec == 4] = 1
+    indivi.activite.loc[indivi.actrec == 5] = 2
+    indivi.activite.loc[indivi.actrec == 7] = 3
+    indivi.activite.loc[indivi.actrec == 8] = 4
+    indivi.activite.loc[indivi.age <= 13] = 2  # ce sont en fait les actrec=9
     log.info("{}".format(indivi['activite'].value_counts(dropna = False)))
     # TODO: MBJ problem avec les actrec
     # TODO: FIX AND REMOVE
-    indivi.activite[indivi.actrec.isnull()] = 5
-    indivi.titc[indivi.titc.isnull()] = 0
+    indivi.activite.loc[indivi.actrec.isnull()] = 5
+    indivi.titc.loc[indivi.titc.isnull()] = 0
     assert indivi.titc.notnull().all(), u"Problème avec les titc" # On a 420 NaN pour les varaibels statut, titc etc
 
     log.info(u"    6.2 : variable statut")
-    indivi.statut[indivi.statut.isnull()] = 0
+    indivi.statut.loc[indivi.statut.isnull()] = 0
     indivi.statut = indivi.statut.astype('int')
-    indivi.statut[indivi.statut == 11] = 1
-    indivi.statut[indivi.statut == 12] = 2
-    indivi.statut[indivi.statut == 13] = 3
-    indivi.statut[indivi.statut == 21] = 4
-    indivi.statut[indivi.statut == 22] = 5
-    indivi.statut[indivi.statut == 33] = 6
-    indivi.statut[indivi.statut == 34] = 7
-    indivi.statut[indivi.statut == 35] = 8
-    indivi.statut[indivi.statut == 43] = 9
-    indivi.statut[indivi.statut == 44] = 10
-    indivi.statut[indivi.statut == 45] = 11
+    indivi.statut.loc[indivi.statut == 11] = 1
+    indivi.statut.loc[indivi.statut == 12] = 2
+    indivi.statut.loc[indivi.statut == 13] = 3
+    indivi.statut.loc[indivi.statut == 21] = 4
+    indivi.statut.loc[indivi.statut == 22] = 5
+    indivi.statut.loc[indivi.statut == 33] = 6
+    indivi.statut.loc[indivi.statut == 34] = 7
+    indivi.statut.loc[indivi.statut == 35] = 8
+    indivi.statut.loc[indivi.statut == 43] = 9
+    indivi.statut.loc[indivi.statut == 44] = 10
+    indivi.statut.loc[indivi.statut == 45] = 11
     assert indivi.statut.isin(range(12)).all(), u"statut value over range"
 
 
@@ -391,13 +391,13 @@ def create_totals(temporary_store = None, year = None):
 
     indivi.nbsala.fillna(0, inplace = True)
     indivi['nbsala'] = indivi.nbsala.astype('int')
-    indivi.nbsala[indivi.nbsala == 99] = 10
+    indivi.nbsala.loc[indivi.nbsala == 99] = 10
     assert indivi.nbsala.isin(range(11)).all()
 
     log.info(u"    6.4 : variable chpub et CSP")
     indivi.chpub.fillna(0, inplace = True)
     indivi.chpub = indivi.chpub.astype('int')
-    indivi.chpub[indivi.chpub.isnull()] = 0
+    indivi.chpub.loc[indivi.chpub.isnull()] = 0
     assert indivi.chpub.isin(range(11)).all()
 
     indivi['cadre'] = 0
@@ -407,13 +407,13 @@ def create_totals(temporary_store = None, year = None):
 
     # encadr : 1=oui, 2=non
     indivi.encadr.fillna(2, inplace = True)
-    indivi.encadr[indivi.encadr == 0] = 2
+    indivi.encadr.loc[indivi.encadr == 0] = 2
 
     assert indivi.encadr.notnull().all()
     assert indivi.encadr.isin([1, 2]).all()
 
-    indivi['cadre'][indivi.prosa.isin([7, 8])] = 1
-    indivi['cadre'][(indivi.prosa == 9) & (indivi.encadr == 1)] = 1
+    indivi.cadre.loc[indivi.prosa.isin([7, 8])] = 1
+    indivi.cadre.loc[(indivi.prosa == 9) & (indivi.encadr == 1)] = 1
 
     assert indivi['cadre'].isin(range(2)).all()
 
@@ -426,9 +426,9 @@ def create_totals(temporary_store = None, year = None):
     assert indivi['idfoy'].notnull().all()
     print_id(indivi)
     indivi['quifoy2'] = 2
-    indivi.quifoy2[indivi.quifoy == 'vous'] = 0
-    indivi.quifoy2[indivi.quifoy == 'conj'] = 1
-    indivi.quifoy2[indivi.quifoy == 'pac'] = 2
+    indivi.quifoy2.loc[indivi.quifoy == 'vous'] = 0
+    indivi.quifoy2.loc[indivi.quifoy == 'conj'] = 1
+    indivi.quifoy2.loc[indivi.quifoy == 'pac'] = 2
 
     del indivi['quifoy']
     indivi['quifoy'] = indivi.quifoy2

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_07_invalides.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_07_invalides.py
@@ -89,7 +89,7 @@ def invalide(temporary_store = None, year = None):
         assert invalides[var].notnull().all(), 'NaN values in {}'.format(var)
 
     # Les déclarants invalides
-    invalides['invalide'][(invalides['caseP'] == 1) & (invalides['quifoy'] == 0)] = True
+    invalides.invalide.loc[(invalides['caseP'] == 1) & (invalides['quifoy'] == 0)] = True
     log.info(u"Il y a {} invalides déclarants".format(invalides["invalide"].sum()))
 
     # Les personnes qui touchent l'aah dans l'enquête emploi

--- a/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_08_final.py
+++ b/openfisca_france_data/input_data_builders/build_openfisca_survey_data/step_08_final.py
@@ -267,7 +267,7 @@ def final(temporary_store = None, year = None, check = True):
     proba_zone_2 = probs['proba_zone2'].values[0]
 
     final2["zone_apl"] = 3
-    final2["zone_apl"][indices] = (
+    final2.zone_apl.loc[indices] = (
         1 + (z > proba_zone_1) + (z > (proba_zone_1 + proba_zone_2))
         )
     del indices, probs


### PR DESCRIPTION
Reduce number of warning related to returning  view vs a copy issues by using .loc
(http://pandas.pydata.org/pandas-docs/stable/indexing.html#returning-a-view-versus-a-copy)

Results looks ok and test_agregates seams to return the same values has before, but this might need to be checked/compared more deeply.

Step_02 imputation has not been changed.