### PR TITLE
Remove __future__ expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.7.7 [145](https://github.com/openfisca/openfisca-france-data/pull/145)
+
+- Remove `__future__` imports
+  - They make sense no more as we've migrated to the Python 3 interpreter
+
 ### 0.7.6 [146](https://github.com/openfisca/openfisca-france-data/pull/146)
 
 - Limit code coverage to the `openfisca-france-data` package

--- a/openfisca_france_data/__init__.py
+++ b/openfisca_france_data/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
 import inspect
 import logging
 import os

--- a/openfisca_france_data/aggregates.py
+++ b/openfisca_france_data/aggregates.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
 import collections
 from datetime import datetime
 import logging

--- a/openfisca_france_data/assets/zone_apl_data/zone_apl/zone_apl_imputation_data_reader.py
+++ b/openfisca_france_data/assets/zone_apl_data/zone_apl/zone_apl_imputation_data_reader.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
 import pickle
 from pandas import read_csv, DataFrame
 import numpy as np

--- a/openfisca_france_data/debugger.py
+++ b/openfisca_france_data/debugger.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
-
 import logging
 
 

--- a/openfisca_france_data/erfs/input_data_builder/step_02_imputation_loyer.py
+++ b/openfisca_france_data/erfs/input_data_builder/step_02_imputation_loyer.py
@@ -8,9 +8,6 @@
 # (the version on python website is not compatible, working correctly for the debian's testing version)
 
 
-from __future__ import division
-
-
 import gc
 import logging
 import numpy

--- a/openfisca_france_data/erfs/input_data_builder/step_03_fip.py
+++ b/openfisca_france_data/erfs/input_data_builder/step_03_fip.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
-
 import gc
 import logging
 

--- a/openfisca_france_data/erfs/input_data_builder/step_05_foyer.py
+++ b/openfisca_france_data/erfs/input_data_builder/step_05_foyer.py
@@ -7,9 +7,6 @@
 # Creates sif and foyer_aggr
 
 
-from __future__ import division
-
-
 import gc
 import logging
 

--- a/openfisca_france_data/erfs/input_data_builder/step_08_final.py
+++ b/openfisca_france_data/erfs/input_data_builder/step_08_final.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
 import gc
 
 import logging

--- a/openfisca_france_data/erfs/input_data_builder/step_10_check_final2.py
+++ b/openfisca_france_data/erfs/input_data_builder/step_10_check_final2.py
@@ -1,7 +1,6 @@
 ## -*- coding: utf-8 -*-
 
 
-from __future__ import division
 from numpy import where, NaN, random
 from openfisca_france.data.erf.build_survey import show_temp, load_temp, save_temp
 from openfisca_france.data.erf.build_survey.utils import print_id, control, check_structure

--- a/openfisca_france_data/erfs_fpr/get_survey_scenario.py
+++ b/openfisca_france_data/erfs_fpr/get_survey_scenario.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
-
 from openfisca_france_data.erfs_fpr.scenario import ErfsFprSurveyScenario
 from openfisca_france_data.tests import base as base_survey
 

--- a/openfisca_france_data/erfs_fpr/input_data_builder/step_02_imputation_loyer.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/step_02_imputation_loyer.py
@@ -18,9 +18,6 @@ There are two ways of doing that:
 # (the version on python website is not compatible, working correctly for the debian's testing version)
 
 
-from __future__ import division
-
-
 import gc
 import logging
 import numpy

--- a/openfisca_france_data/erfs_fpr/input_data_builder/step_03_variables_individuelles.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/step_03_variables_individuelles.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 import numpy as np
 import pandas as pd

--- a/openfisca_france_data/model/calage.py
+++ b/openfisca_france_data/model/calage.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
 from itertools import izip
 
 from numpy import arange, array, floor, where

--- a/openfisca_france_data/model/common.py
+++ b/openfisca_france_data/model/common.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
 from numpy import arange
 
 

--- a/openfisca_france_data/reforms/inversion_directe_salaires.py
+++ b/openfisca_france_data/reforms/inversion_directe_salaires.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import numpy as np
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france_data/tests/erfs_fpr/test_af.py
+++ b/openfisca_france_data/tests/erfs_fpr/test_af.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 #%%
 
-from __future__ import division
-
-
 from openfisca_france_data.erfs_fpr.get_survey_scenario import get_survey_scenario
 
 

--- a/openfisca_france_data/tests/erfs_fpr/test_aggregates.py
+++ b/openfisca_france_data/tests/erfs_fpr/test_aggregates.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 import logging
 import numpy as np
 

--- a/openfisca_france_data/tests/erfs_fpr/test_al.py
+++ b/openfisca_france_data/tests/erfs_fpr/test_al.py
@@ -4,9 +4,6 @@
 #%%
 
 
-from __future__ import division
-
-
 from openfisca_france_data.erfs_fpr.get_survey_scenario import get_survey_scenario
 
 

--- a/openfisca_france_data/tests/erfs_fpr/test_impot_revenu.py
+++ b/openfisca_france_data/tests/erfs_fpr/test_impot_revenu.py
@@ -4,9 +4,6 @@
 #%%
 
 
-from __future__ import division
-
-
 import os
 
 from openfisca_france_data.erfs_fpr.get_survey_scenario import get_survey_scenario

--- a/openfisca_france_data/tests/erfs_fpr/test_rebuild_input_data.py
+++ b/openfisca_france_data/tests/erfs_fpr/test_rebuild_input_data.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
-
 import logging
 import numpy as np
 

--- a/openfisca_france_data/tests/erfs_fpr/test_rsa.py
+++ b/openfisca_france_data/tests/erfs_fpr/test_rsa.py
@@ -3,9 +3,6 @@
 
 #%%
 
-from __future__ import division
-
-
 import logging
 
 

--- a/openfisca_france_data/tests/erfs_fpr/test_salaire_imposable.py
+++ b/openfisca_france_data/tests/erfs_fpr/test_salaire_imposable.py
@@ -3,9 +3,6 @@
 
 #%%
 
-from __future__ import division
-
-
 from openfisca_france_data.erfs_fpr.get_survey_scenario import get_survey_scenario
 
 

--- a/openfisca_france_data/tests/test_aggregates.py
+++ b/openfisca_france_data/tests/test_aggregates.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 import logging
 import numpy as np
 

--- a/openfisca_france_data/tests/test_combining_reforms.py
+++ b/openfisca_france_data/tests/test_combining_reforms.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
-
 from openfisca_france_data.tests import base as base_survey
 
 

--- a/openfisca_france_data/tests/test_fake_survey_simulation.py
+++ b/openfisca_france_data/tests/test_fake_survey_simulation.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
 import numpy
 import os
 import pandas

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-France-Data',
-    version = '0.7.6',
+    version = '0.7.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
#### Technical changes

- Remove `__future__` imports
  - They make sense no more as we've migrated to the Python 3 interpreter