### PR TITLE
Ne charge OpenFisca-France qu'une seule fois

### DIFF
--- a/openfisca_france_data/common.py
+++ b/openfisca_france_data/common.py
@@ -7,7 +7,9 @@ from openfisca_core import periods
 from openfisca_core.taxscales import MarginalRateTaxScale, combine_tax_scales
 from openfisca_core.formula_helpers import switch
 from openfisca_france.model.base import TypesCategorieSalarie, TAUX_DE_PRIME
-from openfisca_france import FranceTaxBenefitSystem
+from openfisca_france_data import openfisca_france_tax_benefit_system    
+
+
 
 log = logging.getLogger(__name__)
 
@@ -15,7 +17,7 @@ log = logging.getLogger(__name__)
 smic_horaire_brut = dict()
 for year in range(2010,2020):
     try:
-        smic_horaire_brut[year] = FranceTaxBenefitSystem().get_parameters_at_instant(instant = periods.period(year).start).cotsoc.gen.smic_h_b
+        smic_horaire_brut[year] = openfisca_france_tax_benefit_system.get_parameters_at_instant(instant = periods.period(year).start).cotsoc.gen.smic_h_b
     except:
         continue
 

--- a/openfisca_france_data/erfs_fpr/input_data_builder/step_03_variables_individuelles.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/step_03_variables_individuelles.py
@@ -13,6 +13,7 @@ from openfisca_france_data.common import (
     create_traitement_indiciaire_brut,
     create_revenus_remplacement_bruts,
     )
+from openfisca_france_data import openfisca_france_tax_benefit_system    
 from openfisca_france_data.utils import assert_dtype
 from openfisca_survey_manager.temporary import temporary_store_decorator
 
@@ -32,7 +33,7 @@ log = logging.getLogger(__name__)
 smic_horaire_brut = dict()
 for year in range(2010, 2020):
     try:
-        smic_horaire_brut[year] = FranceTaxBenefitSystem().get_parameters_at_instant(instant = periods.period(year).start).cotsoc.gen.smic_h_b
+        smic_horaire_brut[year] = openfisca_france_tax_benefit_system.get_parameters_at_instant(instant = periods.period(year).start).cotsoc.gen.smic_h_b
     except:
         continue
 
@@ -80,7 +81,7 @@ smic_annuel_imposbale_by_year = dict([
 
 
 smic_horaire_brut_by_year = dict([
-    (year, FranceTaxBenefitSystem().get_parameters_at_instant(instant = periods.period(year).start).cotsoc.gen.smic_h_b)
+    (year, openfisca_france_tax_benefit_system.get_parameters_at_instant(instant = periods.period(year).start).cotsoc.gen.smic_h_b)
     for year in range(2005, 2020)
     ])
 
@@ -146,7 +147,7 @@ def create_variables_individuelles(individus, year, survey_year = None):
     # On fait ça car, aussi bien le TaxBenefitSystem et celui réformé peuvent être des réformes
     # Par exemple : si je veux calculer le diff entre le PLF2019 et un ammendement,
     # je besoin d'un droit courantcomme même du droit currant pour l'année des données
-    tax_benefit_system = FranceTaxBenefitSystem()
+    tax_benefit_system = openfisca_france_tax_benefit_system
 
     # On n'a pas le salaire brut mais le salaire net ou imposable, on doit l'invertir
     create_salaire_de_base(individus, period = period, revenu_type = revenu_type, tax_benefit_system = tax_benefit_system)
@@ -621,8 +622,6 @@ def create_categorie_non_salarie(individus):
             ),
         'categorie_salarie'
         ] = 2
-
-
 
 
 def create_contrat_de_travail(individus, period, salaire_type = 'imposable'):

--- a/openfisca_france_data/utils.py
+++ b/openfisca_france_data/utils.py
@@ -10,6 +10,9 @@ import openfisca_france  # type: ignore
 from openfisca_survey_manager.survey_collections import SurveyCollection  # type: ignore
 from openfisca_survey_manager.surveys import Survey  # type: ignore
 
+from openfisca_france_data import openfisca_france_tax_benefit_system    
+
+
 log = logging.getLogger(__name__)
 
 
@@ -232,7 +235,7 @@ def check_structure(dataframe):
 
 
 def build_cerfa_fields_by_column_name(year, sections_cerfa):
-    tax_benefit_system = openfisca_france.FranceTaxBenefitSystem()
+    tax_benefit_system = openfisca_france_tax_benefit_system
     cerfa_fields_by_column_name = dict()
     for name, column in tax_benefit_system.variables.items():
         for section_cerfa in sections_cerfa:
@@ -249,7 +252,7 @@ def build_cerfa_fields_by_column_name(year, sections_cerfa):
 
 
 def build_cerfa_fields_by_variable(year):
-    tax_benefit_system = openfisca_france.FranceTaxBenefitSystem()
+    tax_benefit_system = openfisca_france_tax_benefit_system
     cerfa_fields_by_variable = dict()
     for name, variable in sorted(tax_benefit_system.variables.items()):
         if variable.cerfa_field is None:
@@ -319,8 +322,7 @@ def normalizes_roles_in_entity(dataframe, entity_id_name, entity_role_name):
 
 
 def set_variables_default_value(dataframe, year):
-    import openfisca_france
-    tax_benefit_system = openfisca_france.FranceTaxBenefitSystem()
+    tax_benefit_system = openfisca_france_tax_benefit_system
 
     for column_name, column in tax_benefit_system.variables.items():
         if column_name in dataframe.columns:


### PR DESCRIPTION
Ça devrait accélérer considérablement le rebuild des données. 

J'observe un gain de x4 de temps de calcul pour une population de 10000 individus.