### PR TITLE
Exports flattened output for erfs_fpr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## 0.12.0 [173](https://github.com/openfisca/openfisca-france-data/pull/173
+## 0.13.0 [177](https://github.com/openfisca/openfisca-france-data/pull/177)
+
+- Introduce a file export that contains only one flattened table (`dummy_data.h5`) instead of exporting a file with several tables.
+  - Adds `export_flattened_df` argument in `create_input_data_frame function`.
+- Bump `numexpr` top version.
+
+## 0.12.0 [173](https://github.com/openfisca/openfisca-france-data/pull/173)
 
 - Get some cleaner stuff from IPP modifs from CASD.
 
-### 0.11.1 [172](https://github.com/openfisca/openfisca-france-data/pull/172
+### 0.11.1 [172](https://github.com/openfisca/openfisca-france-data/pull/172)
 
 - Fix numpy dependency to deal with openfisca-survey-manager deps (see https://github.com/openfisca/openfisca-survey-manager/pull/79).
 

--- a/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
@@ -54,7 +54,7 @@ def build(year: int) -> None:
     #
     # On crée une df par entité par période.
     # Elles sont stockées dans un fichier h5
-    final.create_input_data_frame(year = year,export_flattened_df=True)
+    final.create_input_data_frame(year = year, export_flattened_df=True)
 
 
 if __name__ == '__main__':

--- a/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 #@dispatch(int)
-def build(year: int) -> None:
+def build(year: int, export_flattened_df_filepath: str = None) -> None:
     """
     Ici on va nettoyer et formatter les donnés ERFS-FPR, pour les rendre OpenFisca-like
     """
@@ -54,7 +54,7 @@ def build(year: int) -> None:
     #
     # On crée une df par entité par période.
     # Elles sont stockées dans un fichier h5
-    final.create_input_data_frame(year = year, export_flattened_df_filepath="./dummy_data.h5")
+    final.create_input_data_frame(year = year, export_flattened_df_filepath = export_flattened_df_filepath)
 
 
 if __name__ == '__main__':
@@ -62,8 +62,11 @@ if __name__ == '__main__':
     import time
     start = time.time()
     logging.basicConfig(level = logging.INFO, stream = sys.stdout)
+
     year = 2014
-    build(year = year)
+    export_flattened_df_filepath = "./dummy_data.h5"  # Could be disabled with None
+    build(year = year, export_flattened_df_filepath = export_flattened_df_filepath)
     # TODO: create_enfants_a_naitre(year = year)
+
     log.info("Script finished after {}".format(time.time() - start))
     print(time.time() - start)

--- a/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
@@ -54,7 +54,7 @@ def build(year: int) -> None:
     #
     # On crée une df par entité par période.
     # Elles sont stockées dans un fichier h5
-    final.create_input_data_frame(year = year, export_flattened_df="./dummy_data.h5")
+    final.create_input_data_frame(year = year, export_flattened_df_filepath="./dummy_data.h5")
 
 
 if __name__ == '__main__':

--- a/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
@@ -54,7 +54,7 @@ def build(year: int) -> None:
     #
     # On crée une df par entité par période.
     # Elles sont stockées dans un fichier h5
-    final.create_input_data_frame(year = year, export_flattened_df=True)
+    final.create_input_data_frame(year = year, export_flattened_df="./dummy_data.h5")
 
 
 if __name__ == '__main__':

--- a/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/__init__.py
@@ -54,7 +54,7 @@ def build(year: int) -> None:
     #
     # On crée une df par entité par période.
     # Elles sont stockées dans un fichier h5
-    final.create_input_data_frame(year = year)
+    final.create_input_data_frame(year = year,export_flattened_df=True)
 
 
 if __name__ == '__main__':

--- a/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @temporary_store_decorator(file_name = 'erfs_fpr')
-def create_input_data_frame(temporary_store = None, year = None,export_flattened_df=False):
+def create_input_data_frame(temporary_store = None, year = None, export_flattened_df=False):
     assert temporary_store is not None
     assert year is not None
 
@@ -96,9 +96,13 @@ def create_input_data_frame(temporary_store = None, year = None,export_flattened
 
     individus = format_ids_and_roles(individus)
     if export_flattened_df:
-        supermerge=individus.merge(menages,right_index=True,left_on="idmen",suffixes=("","_x"))
+        supermerge=individus.merge(
+            menages,
+            right_index = True,
+            left_on = "idmen",
+            suffixes = ("","_x"))
         print(len(individus),len(supermerge))
-        supermerge.to_hdf("dummy_data.h5",key="input")
+        supermerge.to_hdf("dummy_data.h5", key = "input")
     # Enters the individual table into the openfisca_erfs_fpr collection
     set_table_in_survey(
         individus,

--- a/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @temporary_store_decorator(file_name = 'erfs_fpr')
-def create_input_data_frame(temporary_store = None, year = None):
+def create_input_data_frame(temporary_store = None, year = None,export_flattened_df=False):
     assert temporary_store is not None
     assert year is not None
 
@@ -95,7 +95,11 @@ def create_input_data_frame(temporary_store = None, year = None):
         )
 
     individus = format_ids_and_roles(individus)
-
+    if export_flattened_df:
+        supermerge=individus.merge(menages,right_index=True,left_on="idmen",suffixes=("","_x"))
+        print(len(individus),len(supermerge))
+        supermerge.to_hdf("dummy_data.h5",key="input")
+    # Enters the individual table into the openfisca_erfs_fpr collection
     set_table_in_survey(
         individus,
         entity = "individu",
@@ -103,6 +107,7 @@ def create_input_data_frame(temporary_store = None, year = None):
         collection = "openfisca_erfs_fpr",
         survey_name = 'input',
         )
+
 
     # assert 'f4ba' in data_frame.columns
 

--- a/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @temporary_store_decorator(file_name = 'erfs_fpr')
-def create_input_data_frame(temporary_store = None, year = None, export_flattened_df=False):
+def create_input_data_frame(temporary_store = None, year = None, export_flattened_df_filepath = None):
     assert temporary_store is not None
     assert year is not None
 
@@ -95,13 +95,13 @@ def create_input_data_frame(temporary_store = None, year = None, export_flattene
         )
 
     individus = format_ids_and_roles(individus)
-    if export_flattened_df:
-        supermerge=individus.merge(
+    if export_flattened_df_filepath:
+        supermerge = individus.merge(
             menages,
             right_index = True,
             left_on = "idmen",
             suffixes = ("", "_x"))
-        supermerge.to_hdf("dummy_data.h5", key = "input")
+        supermerge.to_hdf(export_flattened_df_filepath, key = "input")
     # Enters the individual table into the openfisca_erfs_fpr collection
     set_table_in_survey(
         individus,

--- a/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
+++ b/openfisca_france_data/erfs_fpr/input_data_builder/step_05_final.py
@@ -100,8 +100,7 @@ def create_input_data_frame(temporary_store = None, year = None, export_flattene
             menages,
             right_index = True,
             left_on = "idmen",
-            suffixes = ("","_x"))
-        print(len(individus),len(supermerge))
+            suffixes = ("", "_x"))
         supermerge.to_hdf("dummy_data.h5", key = "input")
     # Enters the individual table into the openfisca_erfs_fpr collection
     set_table_in_survey(
@@ -215,7 +214,7 @@ if __name__ == '__main__':
     logging.basicConfig(level = logging.INFO, stream = sys.stdout)
     year = 2014
     data_frame = create_input_data_frame(year = year)
-    print('ok')
+    log.info('Ok')
 
 # TODO
 # Variables revenus collectifs

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('LICENSE') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "0.12.0",
+    version = "0.13.0",
     description = "OpenFisca-France module to work with French survey data",
     long_description = long_description,
     author = "OpenFisca Team",

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
         "openfisca-core >= 34.2.2, < 35.0.0",
         "openFisca-france >= 42.1.0, < 43.0.0",
         "openFisca-survey-manager >= 0.24, < 1.0.0",
-        "numpy >= 1.11,<1.16",  # openfisca-survey-manager deps and https://github.com/openfisca/openfisca-survey-manager/pull/79
-        "numexpr == 2.6.8",
+        "numpy >= 1.11, < 1.16",  # openfisca-survey-manager deps and https://github.com/openfisca/openfisca-survey-manager/pull/79
+        "numexpr >= 2.6.8, < 2.8.0",
         "pandas >= 0.20.3, < 1.0.0",
         "tables >= 3.0.0, < 4.0.0",  # Needed by pandas.HDFStore
         "wquantiles >= 0.3.0, < 1.0.0"  # To compute weighted quantiles


### PR DESCRIPTION
#### New features

- Introduce `export_flattened_df` argument in `create_input_data_frame` function
  - Allows for one `dummy_data.h5` file export that contains only one flattened table (one line per individual) instead of exporting an h5 file with several tables (one with individual and one for households). This fits better certain ways of importing back the data into openfisca (e.g. LexImpact).
- Upgrade `numexpr` top version to the version used by Core.

