### PR TITLE
Fix pypi upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
 
-### 0.14 [#187](https://github.com/openfisca/openfisca-france-data/pull/187)
+### 0.14.1 [#188](https://github.com/openfisca/openfisca-france-data/pull/188)
 
 * Technical changes
-- Migrate CI from Travis to CircleCI
-- Contains #161, #171, #172, #173, #179, #183, #186
+  - Fix pypi upload by fixing package description
+    - Fix this [CircleCI](https://circleci.com/gh/openfisca/openfisca-france-data/663) error: `The description failed to render in the default format of reStructuredText.`
+
+## 0.14 [#187](https://github.com/openfisca/openfisca-france-data/pull/187)
+
+* Technical changes
+  - Migrate CI from Travis to CircleCI
+  - Reset `master` branch as default branch instead of `release/1.0.0`
+    - Contains [#161](https://github.com/openfisca/openfisca-france-data/pull/161), [#171](https://github.com/openfisca/openfisca-france-data/pull/171), [#172](https://github.com/openfisca/openfisca-france-data/pull/172), [#173](https://github.com/openfisca/openfisca-france-data/pull/173), [#179](https://github.com/openfisca/openfisca-france-data/pull/179), [#183](https://github.com/openfisca/openfisca-france-data/pull/183), [#186](https://github.com/openfisca/openfisca-france-data/pull/186)
 
 ### 0.13.2 [#186](https://github.com/openfisca/openfisca-france-data/pull/186)
 
 * Technical changes
-- Various cleaning
-- Introduction of MTR calculation
+  - Various cleaning
+  - Introduction of MTR calculation
 
 ### 0.13.1 [#179](https://github.com/openfisca/openfisca-france-data/pull/179)
 

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,21 @@
 # -*- coding: utf-8 -*-
 
-
 from setuptools import setup, find_packages
+
 
 with open('README.md') as file:
     long_description = file.read()
-
-with open('LICENSE') as file:
-    license = file.read()
 
 setup(
     name = "OpenFisca-France-Data",
     version = "0.14.0",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
+    long_description_content_type="text/markdown",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     url = "https://github.com/openfisca/openfisca-france-data",
-    license = license,
+    license = "http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     keywords = "tax benefit social survey data microsimulation",
     classifiers = [
         "Development Status :: 2 - Pre-Alpha",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "0.14.0",
+    version = "0.14.1",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### Technical changes

- Fix pypi upload by fixing package description
  - [CircleCI](https://circleci.com/gh/openfisca/openfisca-france-data/663) error fixed: `The description failed to render in the default format of reStructuredText.`