### PR TITLE
corrige typo compute taux csg remplacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.21.1 [#207](https://github.com/openfisca/openfisca-france-data/pull/207)
+
+* Technical changes
+  - Corrects two typos in the create_taux_csg_remplacement function used in the income inversion.
+
 ### 0.21 [#205](https://github.com/openfisca/openfisca-france-data/pull/205)
 
 * Technical changes

--- a/openfisca_france_data/felin/input_data_builder/create_variables_individuelles.py
+++ b/openfisca_france_data/felin/input_data_builder/create_variables_individuelles.py
@@ -24,7 +24,7 @@ def create_taux_csg_remplacement(individus, period, tax_benefit_system, sigma = 
         seuil_reduction = seuils.seuil_de_rfr_2 + (nbptr - 1) * seuils.demi_part_suppl
         taux_csg_remplacement = 0.0 * rfr
         if period.start.year >= 2019:
-            seuil_taux_intermédiaire = seuils.seuil_rfr3 + (nbptr - 1) * seuils.demi_part_suppl_rfr3
+            seuil_taux_intermediaire = seuils.seuil_rfr3 + (nbptr - 1) * seuils.demi_part_suppl_rfr3
             taux_csg_remplacement = np.where(
                 rfr <= seuil_exoneration,
                 1,

--- a/openfisca_france_data/felin/input_data_builder/create_variables_individuelles.py
+++ b/openfisca_france_data/felin/input_data_builder/create_variables_individuelles.py
@@ -31,7 +31,7 @@ def create_taux_csg_remplacement(individus, period, tax_benefit_system, sigma = 
                 np.where(
                     rfr <= seuil_reduction,
                     2,
-                    nb.where(
+                    np.where(
                         rfr <= seuil_taux_intermediaire,
                         3,
                         4,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "0.21",
+    version = "0.21.1",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### Technical changes

  - Corrects two typos in the `create_taux_csg_remplacement` function used in the income inversion.
