### PR TITLE
Remove Conda publish from Gitlab-CI 

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -4,7 +4,7 @@
 ###############################################################################
 
 {% set name = "openfisca-france-data" %}
-{% set version = "0.22.0" %}
+{% set version = "0.22.1" %}
 
 package:
   name: {{ name|lower }}

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -4,7 +4,7 @@
 ###############################################################################
 
 {% set name = "openfisca-france-data" %}
-{% set version = "0.23.0" %}
+{% set version = "0.22.0" %}
 
 package:
   name: {{ name|lower }}

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -4,7 +4,7 @@
 ###############################################################################
 
 {% set name = "openfisca-france-data" %}
-{% set version = "0.22.0" %}
+{% set version = "0.23.0" %}
 
 package:
   name: {{ name|lower }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 
 ################################################
 # GENERATED FILE, DO NOT EDIT
-# Please visit runner/README.md
+# Please visit ci-runner/README.md
 ################################################
 
 variables:
@@ -29,7 +29,7 @@ stages:
 before_script:
   # To be sure we are up to date even if we do not rebuild docker image
   - make install
-  - cp ./runner/openfisca_survey_manager_raw_data.ini ~/.config/openfisca-survey-manager/raw_data.ini
+  - cp ./ci-runner/openfisca_survey_manager_raw_data.ini ~/.config/openfisca-survey-manager/raw_data.ini
   - echo "End of before_script"
 
 build docker image:
@@ -86,7 +86,7 @@ build_collection:
   - echo "Begin with fresh config"
   - mkdir -p $ROOT_FOLDER/data_collections/$OUT_FOLDER/
   - rm $ROOT_FOLDER/data_collections/$OUT_FOLDER/*.json || true
-  - cp ./runner/openfisca_survey_manager_config.ini ~/.config/openfisca-survey-manager/config.ini
+  - cp ./ci-runner/openfisca_survey_manager_config.ini ~/.config/openfisca-survey-manager/config.ini
   - echo "Custom output folder"
   - sed -i "s/data_collections/data_collections\/$OUT_FOLDER\//" ~/.config/openfisca-survey-manager/config.ini
   - cat ~/.config/openfisca-survey-manager/config.ini

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,18 +68,6 @@ build_conda_package:
   - conda build -c conda-forge -c openfisca --token $ANACONDA_TOKEN --user OpenFisca
     .conda
   stage: anaconda
-build_and_deploy_conda_package:
-  before_script:
-  - ''
-  image: continuumio/miniconda3
-  only:
-  - master
-  script:
-  - conda install -y conda-build anaconda-client
-  - conda config --set anaconda_upload yes
-  - conda build -c conda-forge -c openfisca --token $ANACONDA_TOKEN --user OpenFisca
-    .conda
-  stage: anaconda
 build_collection:
   image: $CI_REGISTRY_IMAGE:latest
   script:
@@ -98,6 +86,666 @@ build_collection:
   tags:
   - openfisca
   when: manual
+in_dt-1996:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-1996"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 1996 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_1996.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1996.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-1996:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-1996
+  script:
+  - echo "aggregates-1996"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1996.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 1996
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-1997:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-1997"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 1997 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_1997.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1997.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-1997:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-1997
+  script:
+  - echo "aggregates-1997"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1997.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 1997
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-1998:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-1998"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 1998 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_1998.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1998.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-1998:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-1998
+  script:
+  - echo "aggregates-1998"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1998.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 1998
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-1999:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-1999"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 1999 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_1999.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1999.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-1999:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-1999
+  script:
+  - echo "aggregates-1999"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-1999.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 1999
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2000:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2000"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2000 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2000.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2000.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2000:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2000
+  script:
+  - echo "aggregates-2000"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2000.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2000
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2001:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2001"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2001 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2001.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2001.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2001:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2001
+  script:
+  - echo "aggregates-2001"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2001.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2001
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2002:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2002"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2002 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2002.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2002.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2002:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2002
+  script:
+  - echo "aggregates-2002"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2002.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2002
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2003:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2003"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2003 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2003.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2003.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2003:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2003
+  script:
+  - echo "aggregates-2003"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2003.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2003
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2004:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2004"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2004 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2004.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2004.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2004:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2004
+  script:
+  - echo "aggregates-2004"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2004.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2004
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2005:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2005"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2005 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2005.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2005.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2005:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2005
+  script:
+  - echo "aggregates-2005"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2005.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2005
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2006:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2006"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2006 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2006.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2006.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2006:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2006
+  script:
+  - echo "aggregates-2006"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2006.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2006
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2007:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2007"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2007 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2007.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2007.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2007:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2007
+  script:
+  - echo "aggregates-2007"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2007.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2007
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2008:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2008"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2008 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2008.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2008.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2008:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2008
+  script:
+  - echo "aggregates-2008"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2008.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2008
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2009:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2009"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2009 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2009.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2009.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2009:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2009
+  script:
+  - echo "aggregates-2009"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2009.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2009
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2010:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2010"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2010 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2010.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2010.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2010:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2010
+  script:
+  - echo "aggregates-2010"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2010.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2010
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2011:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2011"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2011 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2011.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2011.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2011:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2011
+  script:
+  - echo "aggregates-2011"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2011.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2011
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2012:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2012"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2012 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2012.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2012.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2012:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2012
+  script:
+  - echo "aggregates-2012"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2012.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2012
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2013:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2013"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2013 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2013.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2013.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2013:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2013
+  script:
+  - echo "aggregates-2013"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2013.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2013
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2014:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2014"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2014 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2014.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2014.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2014:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2014
+  script:
+  - echo "aggregates-2014"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2014.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2014
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2015:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2015"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2015 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2015.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2015.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2015:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2015
+  script:
+  - echo "aggregates-2015"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2015.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2015
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2016:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2016"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2016 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2016.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2016.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2016:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2016
+  script:
+  - echo "aggregates-2016"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2016.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2016
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2017:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2017"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2017 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2017.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2017.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2017:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2017
+  script:
+  - echo "aggregates-2017"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2017.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2017
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
 in_dt-2018:
   image: $CI_REGISTRY_IMAGE:latest
   script:
@@ -122,6 +770,36 @@ agg-2018:
   - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2018.ini
     ~/.config/openfisca-survey-manager/config.ini
   - python tests/erfs_fpr/integration/test_aggregates.py --year 2018
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
+  - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER
+  stage: aggregates
+  tags:
+  - openfisca
+in_dt-2019:
+  image: $CI_REGISTRY_IMAGE:latest
+  script:
+  - echo "build_input_data-2019"
+  - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config-after-build-collection.ini ~/.config/openfisca-survey-manager/config.ini
+  - build-erfs-fpr -y 2019 -f $ROOT_FOLDER/$OUT_FOLDER/erfs_flat_2019.h5
+  - cp ~/.config/openfisca-survey-manager/config.ini $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2019.ini
+  stage: build_input_data
+  tags:
+  - openfisca
+agg-2019:
+  artifacts:
+    paths:
+    - ./*.html
+    - ./*.csv
+  image: $CI_REGISTRY_IMAGE:latest
+  needs:
+  - in_dt-2019
+  script:
+  - echo "aggregates-2019"
+  - cp $ROOT_FOLDER/openfisca_survey_manager_config_input_data-after-build-erfs-fprs-2019.ini
+    ~/.config/openfisca-survey-manager/config.ini
+  - python tests/erfs_fpr/integration/test_aggregates.py --year 2019
   - mkdir -p $ROOT_FOLDER/$OUT_FOLDER
   - cp ./*.html $ROOT_FOLDER/$OUT_FOLDER
   - cp ./*.csv $ROOT_FOLDER/$OUT_FOLDER

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,11 +20,10 @@ cache:
 stages:
   - docker
   - test
-  - anaconda
   - build_collection
   - build_input_data
   - aggregates
-
+  - anaconda
 
 before_script:
   # To be sure we are up to date even if we do not rebuild docker image
@@ -57,17 +56,6 @@ test:
   stage: test
   tags:
   - openfisca
-build_conda_package:
-  before_script:
-  - ''
-  except:
-  - master
-  image: continuumio/miniconda3
-  script:
-  - conda install -y conda-build anaconda-client
-  - conda build -c conda-forge -c openfisca --token $ANACONDA_TOKEN --user OpenFisca
-    .conda
-  stage: anaconda
 build_collection:
   image: $CI_REGISTRY_IMAGE:latest
   script:
@@ -806,3 +794,14 @@ agg-2019:
   stage: aggregates
   tags:
   - openfisca
+build_conda_package:
+  before_script:
+  - ''
+  except:
+  - master
+  image: continuumio/miniconda3
+  script:
+  - conda install -y conda-build anaconda-client
+  - conda build -c conda-forge -c openfisca --token $ANACONDA_TOKEN --user OpenFisca
+    .conda
+  stage: anaconda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.22.1 [#208](https://github.com/openfisca/openfisca-france-data/pull/208)
+
+* Technical changes
+  -  Remove Conda publish from Gitlab CI
+  -  Put back all years in Gitlab CI
+
 ### 0.22.0 [#206](https://github.com/openfisca/openfisca-france-data/pull/206)
 
 * Technical changes

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ctags:
 	ctags --recurse=yes .
 
 bump:
-	bumpver update --minor
+	bumpver update --patch
 
 build:
 	python3 -m pip install --upgrade build twine

--- a/ci-runner/README.md
+++ b/ci-runner/README.md
@@ -7,7 +7,7 @@ This folder contains files needed for the CI.
 To separate the different years and survey files we have a script that build the CI script.
 
 ```
-python runner/build_ci.py
+python ci-runner/build_ci.py
 ```
 
 It will create the file `.gitlab-ci.yml` that is read by Gitlab Runner to execute the CI.

--- a/ci-runner/build_ci.py
+++ b/ci-runner/build_ci.py
@@ -3,20 +3,20 @@ Create the file `.gitlab-ci.yml` that is read by Gitlab Runner to execute the CI
 
 Run in project root folder:
 
-python runner/build_ci.py
+python ci-runner/build_ci.py
 """
 import configparser
 import yaml
 
 # Config file use to get the available years
-CONFIG = "./runner/openfisca_survey_manager_raw_data.ini"
+CONFIG = "./ci-runner/openfisca_survey_manager_raw_data.ini"
 
 
 def header():
     return """
 ################################################
 # GENERATED FILE, DO NOT EDIT
-# Please visit runner/README.md
+# Please visit ci-runner/README.md
 ################################################
 
 variables:
@@ -44,7 +44,7 @@ stages:
 before_script:
   # To be sure we are up to date even if we do not rebuild docker image
   - make install
-  - cp ./runner/openfisca_survey_manager_raw_data.ini ~/.config/openfisca-survey-manager/raw_data.ini
+  - cp ./ci-runner/openfisca_survey_manager_raw_data.ini ~/.config/openfisca-survey-manager/raw_data.ini
   - echo "End of before_script"
 
 build docker image:
@@ -78,7 +78,7 @@ def build_collections():
                 'echo "Begin with fresh config"',
                 "mkdir -p $ROOT_FOLDER/data_collections/$OUT_FOLDER/",
                 "rm $ROOT_FOLDER/data_collections/$OUT_FOLDER/*.json || true",  # || true to ignore error
-                "cp ./runner/openfisca_survey_manager_config.ini ~/.config/openfisca-survey-manager/config.ini",
+                "cp ./ci-runner/openfisca_survey_manager_config.ini ~/.config/openfisca-survey-manager/config.ini",
                 'echo "Custom output folder"',
                 'sed -i "s/data_collections/data_collections\/$OUT_FOLDER\//" ~/.config/openfisca-survey-manager/config.ini',
                 "cat ~/.config/openfisca-survey-manager/config.ini",

--- a/ci-runner/build_ci.py
+++ b/ci-runner/build_ci.py
@@ -35,11 +35,10 @@ cache:
 stages:
   - docker
   - test
-  - anaconda
   - build_collection
   - build_input_data
   - aggregates
-
+  - anaconda
 
 before_script:
   # To be sure we are up to date even if we do not rebuild docker image
@@ -224,13 +223,13 @@ def build_and_deploy_conda_package():
 def build_gitlab_ci(erfs_years):
     gitlab_ci = header()
     gitlab_ci += yaml.dump(make_test())
-    gitlab_ci += yaml.dump(build_conda_package())
     # gitlab_ci += yaml.dump(build_and_deploy_conda_package())
     gitlab_ci += yaml.dump(build_collections())
     for year in erfs_years:
         print("\t ERFS : Building for year", year)
         gitlab_ci += yaml.dump(build_input_data(year))
         gitlab_ci += yaml.dump(aggregates(year))
+    gitlab_ci += yaml.dump(build_conda_package())
     return gitlab_ci
 
 

--- a/ci-runner/build_ci.py
+++ b/ci-runner/build_ci.py
@@ -225,7 +225,7 @@ def build_gitlab_ci(erfs_years):
     gitlab_ci = header()
     gitlab_ci += yaml.dump(make_test())
     gitlab_ci += yaml.dump(build_conda_package())
-    gitlab_ci += yaml.dump(build_and_deploy_conda_package())
+    # gitlab_ci += yaml.dump(build_and_deploy_conda_package())
     gitlab_ci += yaml.dump(build_collections())
     for year in erfs_years:
         print("\t ERFS : Building for year", year)
@@ -238,7 +238,7 @@ def main():
     print("Reading survey manager config...")
     erfs_years = get_erfs_years()
     # For testing only some years
-    erfs_years = ["2018"]
+    # erfs_years = ["2018"]
     gitlab_ci = build_gitlab_ci(erfs_years)
     with open(r".gitlab-ci.yml", mode="w") as file:
         file.write(gitlab_ci)

--- a/ci-runner/openfisca_survey_manager_config.ini
+++ b/ci-runner/openfisca_survey_manager_config.ini
@@ -1,6 +1,6 @@
 # Template du fichier config.ini de openfisca-survey-manager
 # pour qu'il fonctionne avec oepnfisca-france-data
-# sur le runner gitlab piloté par ipp/openfisca-france/data
+# sur le ci-runner gitlab piloté par ipp/openfisca-france/data
 
 [collections]
 collections_directory = /mnt/data-out/openfisca-france-data/data_collections

--- a/ci-runner/openfisca_survey_manager_raw_data.ini
+++ b/ci-runner/openfisca_survey_manager_raw_data.ini
@@ -1,6 +1,6 @@
 # Template du fichier raw_data.ini de openfisca-survey-manager
 # pour qu'il fonctionne avec oepnfisca-france-data
-# sur le runner gitlab piloté par ipp/openfisca-france/data
+# sur le ci-runner gitlab piloté par ipp/openfisca-france/data
 
 ; [enquete_logement]
 ; 2006 = /home/ipp/data/enquete_logement/2006/stata

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ testpaths       = tests
 python_files    = **/*.py
 
 [bumpver]
-current_version = "0.22.0"
+current_version = "0.23.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ testpaths       = tests
 python_files    = **/*.py
 
 [bumpver]
-current_version = "0.22.0"
+current_version = "0.22.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ testpaths       = tests
 python_files    = **/*.py
 
 [bumpver]
-current_version = "0.23.0"
+current_version = "0.22.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = True

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "0.22.0",
+    version = "0.22.1",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "0.23.0",
+    version = "0.22.0",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "0.22.0",
+    version = "0.23.0",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### Technical changes
- Remove Conda publish from Gitlab CI
- Put back all years in Gitlab CI
- Rename `runner` folder to `ci-runner` to be more explicit

Tested on Gitlab : https://git.leximpact.dev/benjello/openfisca-france-data/-/merge_requests/14