### PR TITLE
Supprime rev_microsocial de salaire_brut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 1.0.0 [#224](https://github.com/openfisca/openfisca-france-data/pull/224)
+
+* Breaking changes
+- dans model/common.py/salaire_brut:
+  - Retire rev_microsocial
+
+- Détails
+  - rev_microsocial n'était pas un salaire mais un CA net des cotisations sociales pour les micro-entrepreneurs optant pour le  versement libératoire de l'IR. Elle était donc à tort dans salaire_brut, d'autant plus qu'il n'y a pas d'autres rpns qui y  sont répertoriés.
+
 ## 0.27 [#223](https://github.com/openfisca/openfisca-france-data/pull/223)
 
 * Technical changes

--- a/openfisca_france_data/model/common.py
+++ b/openfisca_france_data/model/common.py
@@ -313,10 +313,6 @@ class salaire_brut(Variable):
         complementaire_sante_salarie = individu('complementaire_sante_salarie', period)
         indemnite_compensatrice_csg = individu('indemnite_compensatrice_csg', period)
 
-        # Revenu du foyer fiscal projeté sur le demandeur
-        rev_microsocial = individu.foyer_fiscal('rev_microsocial', period, options = [DIVIDE])
-        rev_microsocial_declarant1 = rev_microsocial * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-
         return (
             salaire_de_base
             + primes_salaires
@@ -324,7 +320,6 @@ class salaire_brut(Variable):
             + primes_fonction_publique
             + indemnite_residence
             + supplement_familial_traitement
-            + rev_microsocial_declarant1
             + indemnite_fin_contrat
             + complementaire_sante_salarie
             + indemnite_compensatrice_csg

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "0.27",
+    version = "1.0",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Met à jour d'Openfisca-france, en corrigeant un problème

#### Breaking changes

- dans model/common.py/salaire_brut:
  - Retire rev_microsocial

rev_microsocial n'était pas un salaire mais un CA net des cotisations sociales pour les micro-entrepreneurs optant pour le versement libératoire de l'IR. Elle était donc à tort dans salaire_brut, d'autant plus qu'il n'y a pas d'autres rpns qui y sont répertoriés. 
