### PR TITLE
Add event: push in conda CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -260,6 +260,7 @@ jobs:
           commit: ${{steps.last_pr_commit.outputs.result}}
           name: conda-build-${{ env.PACKAGE_VERSION }}-${{steps.last_pr_commit.outputs.result}}
           path: conda-build-tmp
+          event: push # To avoid conflict with PR workflow
           if_no_artifact_found: fail
       - name: Conda upload
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128


### PR DESCRIPTION
#### Technical changes

- Tentative de fix de https://github.com/openfisca/openfisca-france-data/issues/230 qui se produit quand le wokflow de CI a tourné deux fois pour le même commit, ce qui arrive quand on crée la PR. La solution proposée est de limiter la recherche d’artefact aux workflow lancés par un push. 
