### PR TITLE
Bug/fix conda ci

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -4,7 +4,7 @@
 ###############################################################################
 
 {% set name = "openfisca-france-data" %}
-{% set version = "0.23.1" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -260,6 +260,7 @@ jobs:
           commit: ${{steps.last_pr_commit.outputs.result}}
           name: conda-build-${{ env.PACKAGE_VERSION }}-${{steps.last_pr_commit.outputs.result}}
           path: conda-build-tmp
+          event: push # To avoid conflict with PR workflow
           if_no_artifact_found: fail
       - name: Conda upload
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.0.1 [#232](https://github.com/openfisca/openfisca-france-data/pull/232)
+* Technical changes
+- Fix de #230 qui se produit quand le wokflow de CI a tourné deux fois pour le même commit, ce qui arrive quand on crée la PR. La solution est de limiter la recherche de l’artefact aux workflows lancés par un push.
+
 # 2.0.0 [#229](https://github.com/openfisca/openfisca-france-data/pull/229)
 * Technical changes
 - Met à jour Python dans le setup pour compatibilité conda

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ testpaths       = tests
 python_files    = **/*.py
 
 [bumpver]
-current_version = "0.23.1"
+current_version = "2.0.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = True

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "2.0.0",
+    version = "2.0.1",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Technical changes
  - Fix de #230 qui se produit quand le wokflow de CI a tourné deux fois pour le même commit, ce qui arrive quand on crée la PR. La solution est de limiter la recherche de l’artefact aux workflows lancés par un push.