### PR TITLE
Permet de modifier tax and benefit system dans utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.0.2 [#243](https://github.com/openfisca/openfisca-france-data/pull/243)
+* Technical changes:
+- Ajoute la possibilité d'utiliser un tax and benefit system plus en aval dans les fonctions de utils.py
+
 ### 3.0.1 [#242](https://github.com/openfisca/openfisca-france-data/pull/242)
 * Technical changes:
 - Passage à Openfsca-France >= 155.0.0

--- a/openfisca_france_data/utils.py
+++ b/openfisca_france_data/utils.py
@@ -231,8 +231,7 @@ def check_structure(dataframe):
         return False, erroneous_ids_by_entity
 
 
-def build_cerfa_fields_by_column_name(year, sections_cerfa):
-    tax_benefit_system = openfisca_france_tax_benefit_system
+def build_cerfa_fields_by_column_name(year, sections_cerfa, tax_benefit_system = openfisca_france_tax_benefit_system):
     cerfa_fields_by_column_name = dict()
     for name, column in tax_benefit_system.variables.items():
         for section_cerfa in sections_cerfa:
@@ -248,8 +247,7 @@ def build_cerfa_fields_by_column_name(year, sections_cerfa):
     return cerfa_fields_by_column_name
 
 
-def build_cerfa_fields_by_variable(year):
-    tax_benefit_system = openfisca_france_tax_benefit_system
+def build_cerfa_fields_by_variable(year, tax_benefit_system = openfisca_france_tax_benefit_system):
     cerfa_fields_by_variable = dict()
     for name, variable in sorted(tax_benefit_system.variables.items()):
         if variable.cerfa_field is None:
@@ -318,8 +316,7 @@ def normalizes_roles_in_entity(dataframe, entity_id_name, entity_role_name):
     dataframe[entity_role_name] = dataframe[entity_role_name].astype('int')
 
 
-def set_variables_default_value(dataframe, year):
-    tax_benefit_system = openfisca_france_tax_benefit_system
+def set_variables_default_value(dataframe, year, tax_benefit_system = openfisca_france_tax_benefit_system):
 
     for column_name, column in tax_benefit_system.variables.items():
         if column_name in dataframe.columns:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "3.0.1",
+    version = "3.0.2",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### Technical changes

- Ajoute la possibilité de changer le tax and benefit system dans utils

L'utilisation prévue est pour Taxipp, où certaines variables de salaire doivent être récupérées à partir de Felin, pour compléter celles qui sont présentes dans les DADS. Comme il s'agit d'un cas assez particulier avec une définition de la variable `salaire_imposable ` spécifique (sans les revenus de l'étranger notamment, cases 1af et 1ag, mais en rajoutant notamment les revenus des gérants majoritaires 1gb) et en voulant la construire à partir des DADS, j'ai préféré permettre une utilisation plus souple d'openfisca-france-data (et sans aucune lourdeur supplémentaire a priori) plutôt que de construire dans openfisca-france des variables que nous serions les seuls à utiliser.  
