### PR TITLE
Corrige typo Pypi token

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -146,7 +146,7 @@ jobs:
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
     env:
-      PYPI_TOKEN_OPENFISCA_BOT ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
+      PYPI_TOKEN_OPENFISCA_BOT: ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.0.6 [#248](https://github.com/openfisca/openfisca-france-data/pull/248)
+* Technical changes
+- Correction d'une typo dans la PR précédente
+
 ### 3.0.5 [#247](https://github.com/openfisca/openfisca-france-data/pull/247)
 * Technical changes
 - Pour corriger la publication de la librairie sur PyPi, passe à une authentification PyPi via un token

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "3.0.5",
+    version = "3.0.6",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION


#### Technical changes

- Corrige oubli de `:` dans passage à l'identification au Pypi via token
