### PR TITLE
Separe retraite et chômage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 3.6.0 [#260](https://github.com/openfisca/openfisca-france-data/pull/260)
+
+* Deprecations
+  - Deprecate common.create_revenus_remplacement_bruts.
+  - La fonction est séparée en create_chomage_brut et create_retraite_brute
+
 ### 3.5.0 [#259](https://github.com/openfisca/openfisca-france-data/pull/259)
 
 * New features

--- a/openfisca_france_data/common.py
+++ b/openfisca_france_data/common.py
@@ -408,11 +408,10 @@ def create_traitement_indiciaire_brut(individus, period = None, revenu_type = 'i
     individus['primes_fonction_publique'] = TAUX_DE_PRIME * traitement_indiciaire_brut
 
 
-def create_revenus_remplacement_bruts(individus, period, tax_benefit_system, revenu_type = 'net'):
+def create_chomage_brut(individus, period, tax_benefit_system, revenu_type = 'net'):
     assert 'taux_csg_remplacement' in individus
 
     individus.chomage_imposable.fillna(0, inplace = True)
-    individus.retraite_imposable.fillna(0, inplace = True)
     if revenu_type == 'imposable':
         assert 'salaire_imposable' in individus.columns
         salaire_pour_inversion = individus.salaire_imposable
@@ -468,6 +467,10 @@ def create_revenus_remplacement_bruts(individus, period, tax_benefit_system, rev
     )
     assert individus['chomage_brut'].notnull().all()
 
+def create_retraite_brute(individus, period, tax_benefit_system, revenu_type = 'net'):
+
+    individus.retraite_imposable.fillna(0, inplace = True)
+    parameters = tax_benefit_system.get_parameters_at_instant(period.start)
     csg_deductible_retraite = parameters.prelevements_sociaux.contributions_sociales.csg.remplacement.pensions_retraite_invalidite.deductible
     taux_plein = csg_deductible_retraite.taux_plein
     taux_reduit = csg_deductible_retraite.taux_reduit

--- a/openfisca_france_data/dads/input_data_builder/create_variables_individuelles.py
+++ b/openfisca_france_data/dads/input_data_builder/create_variables_individuelles.py
@@ -2,7 +2,8 @@ from openfisca_france_data.felin.input_data_builder.create_variables_individuell
 from openfisca_france_data.common import (
     create_salaire_de_base,
     create_traitement_indiciaire_brut,
-    create_revenus_remplacement_bruts,
+    create_chomage_brut,
+    create_retraite_brute,
     )
 
 
@@ -47,8 +48,9 @@ def create_individu_variables_brutes(
     create_taux_csg_remplacement(individus, period, tax_benefit_system)
     created_variables.append('taux_csg_remplacement')
 
-    create_revenus_remplacement_bruts(individus, period, tax_benefit_system, revenu_type = revenu_type)
+    create_chomage_brut(individus, period, tax_benefit_system, revenu_type = revenu_type)
     created_variables.append('chomage_brut')
+    create_retraite_brute(individus, period, tax_benefit_system, revenu_type = revenu_type)
     created_variables.append('retraite_brute')
 
     return created_variables

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "3.5.0",
+    version = "3.6.0",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_inversion.py
+++ b/tests/test_inversion.py
@@ -8,7 +8,7 @@ from openfisca_core.periods import *
 from openfisca_france import FranceTaxBenefitSystem
 
 from openfisca_france_data.felin.input_data_builder.create_variables_individuelles import create_taux_csg_remplacement
-from openfisca_france_data.common import create_revenus_remplacement_bruts
+from openfisca_france_data.common import create_chomage_brut, create_retraite_brute
 
 margin = 1
 
@@ -29,7 +29,8 @@ with open(path) as yaml:
 # Inverse incomes from net to gross : the tested functions
 
 create_taux_csg_remplacement(individus, period(year), tax_benefit_system)
-create_revenus_remplacement_bruts(individus, period(year), tax_benefit_system, revenu_type = 'net')
+create_chomage_brut(individus, period(year), tax_benefit_system, revenu_type = 'net')
+create_retraite_brute(individus, period(year), tax_benefit_system, revenu_type = 'net')
 
 # Test against chomage_brut_test
 


### PR DESCRIPTION


#### Deprecations

- Deprecate common.create_revenus_remplacement_bruts.
  - The functionality is now provided by create_chomage_brut and create_retraite_brute
