### PR TITLE
Maj smic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.6.1 [#261](https://github.com/openfisca/openfisca-france-data/pull/261)
+
+* Met à jour le smic net (de manière temporaire en ce qui concerne 2024) pour l'inversion du chômage
+
 ### 3.6.0 [#260](https://github.com/openfisca/openfisca-france-data/pull/260)
 
 * Deprecations

--- a/openfisca_france_data/smic.py
+++ b/openfisca_france_data/smic.py
@@ -28,7 +28,9 @@ for year in range(2002, 2021):
 # partir du chiffre de 2010. Les résultats pour les années après 2010 sont les
 # mêmes à un euro près. 1996-1999 ont la meeeeeême valeur que 2000.
 smic_annuel_net_by_year = {
-    2022: 4 * 1269.02 + 8 * 1302.64, # latest value as of May, assuming no change over the year to come
+    2024: 12 * 1398.70, # en attendant donnees insee banque de donnees macroeconomiques, service public en aout
+    2023: 12 * 1373.07,
+    2022: 12 * 1302.44,
     2021: 9 * 1230.6 + 3 * 1258.22,
 
     2020: 12 * 1218.6,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "3.6.0",
+    version = "3.6.1",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION

#### New features

- Met à jour le smic net (de manière temporaire en ce qui concerne 2024) pour l'inversion du chômage.

Sources : https://www.insee.fr/fr/statistiques/serie/000883658

