### PR TITLE
Calage sur agrégat

### DIFF
--- a/openfisca_france_data/assets/aggregats/demographie/README transition depuis INSEE.txt
+++ b/openfisca_france_data/assets/aggregats/demographie/README transition depuis INSEE.txt
@@ -1,0 +1,2 @@
+Le tableur est issu de https://www.insee.fr/fr/statistiques/5894083?sommaire=5760764 , onglet population. 
+Quelques changements ont été faits pour mieux le parser : conversion en csv, séparateur des milliers mis à "." plutôt qu'à " " (dans Fichier/Options/Options avancées/Utiliser les séparateurs systèmes/Séparateur des milliers), 105 + changé en 105. 

--- a/openfisca_france_data/erfs_fpr/scenario.py
+++ b/openfisca_france_data/erfs_fpr/scenario.py
@@ -9,6 +9,7 @@ class ErfsFprSurveyScenario(AbstractErfsSurveyScenario):
     # Les variables OpenFisca qu'on va utiliser avec les données en entrée.
     used_as_input_variables = [
         "activite",
+        "age",
         #"autonomie_financiere",
         "categorie_salarie",
         "categorie_non_salarie",

--- a/openfisca_france_data/model/calage.py
+++ b/openfisca_france_data/model/calage.py
@@ -1,9 +1,12 @@
-from itertools import izip
+#from itertools import izip
 
 from numpy import arange, array, floor, where
+from numpy import minimum as min_
+import pandas as pd
+from pathlib import Path
 
 from openfisca_france_data.model.base import *  # noqa
-
+from openfisca_france_data import openfisca_france_data_location
 
 class nbinde(Variable):
     value_type = int
@@ -227,3 +230,43 @@ class typmen15(Variable):
         # ratio = (( (typmen15!=res)).sum())/((typmen15!=0).sum())
         # ratio  2.7 % d'erreurs enfant non nés et erreur d'enfants
         return res
+
+def create_dic_calage(year, base_year, liste_variable, **kwargs):
+    dico_calage = dict()
+    assert all(variable in ["age"] for variable in liste_variable), "A variable is asked to be calibrated, but no matching aggregate is implemented"
+    if "age" in liste_variable:
+        dico_calage = create_dic_age(year, base_year, dico_calage, **kwargs)
+    return dico_calage
+
+def create_dic_age(year, base_year, dico_calage, base_initiale = None):
+    demographie_file = Path(
+                openfisca_france_data_location,
+                "openfisca_france_data",
+                "assets",
+                "aggregats",
+                "demographie",
+                "demographie_insee.csv"
+                )
+    df_demographie = pd.read_csv(demographie_file, skipfooter = 9, skiprows = 1, encoding_errors = 'replace', sep = ';', thousands = ".")
+    df_demographie["age_calage"] = df_demographie[df_demographie.columns[0]].astype(int) # On passe par columns à cause du Â
+    for annee in range(base_year, year + 1): # On limite à 100 l'age max, pour éviter l'absence de données
+        df_demographie.loc[df_demographie["age_calage"] == 100, str(annee)] = sum(df_demographie[df_demographie["age_calage"] >= 100][str(annee)])
+    df_demographie = df_demographie[df_demographie["age_calage"] <= 100]
+    if base_initiale is None:
+        dic_age = pd.Series(df_demographie[str(year)].values, index = df_demographie["age_calage"]).to_dict()
+        dico_calage["age_calage"] = dic_age
+        return dico_calage
+
+    df_demographie["variation_totale"] = df_demographie[str(year)] / df_demographie[str(base_year)]
+
+    base_initiale["age_calage"] = base_initiale["age_calage"].astype(int)
+    base_initiale.loc[base_initiale["age_calage"] == 100, "N"] = sum(base_initiale[base_initiale["age_calage"] >= 100]["N"])
+    base_initiale = base_initiale[base_initiale["age_calage"] <= 100]
+
+    cible_finale = pd.merge(df_demographie, base_initiale, on = ("age_calage"), how = "inner")
+    cible_finale["cible"] = round(cible_finale["N"] * cible_finale["variation_totale"])
+    dic_age = pd.Series(cible_finale["cible"].values, index = cible_finale["age_calage"]).to_dict()
+    dico_calage["age_calage"] = dic_age
+    return dico_calage
+
+

--- a/openfisca_france_data/reforms/variables_calibration.py
+++ b/openfisca_france_data/reforms/variables_calibration.py
@@ -1,0 +1,31 @@
+import numpy as np
+from numpy import minimum as min_
+
+from openfisca_france.model.base import *  # noqa analysis:ignore
+from openfisca_core.reforms import Reform
+
+import logging
+
+log = logging.getLogger(__name__)
+def create_calibration_tax_benefit_system(survey_scenario = None):
+    class variables_pour_calibration(Reform):
+        name = 'variables_pour_calibration'
+
+        def apply(self):
+
+            class age_calage(Variable):
+                value_type = str
+                entity = Individu
+                label = "Age censuré pour calage"
+                definition_period = YEAR
+                unit = 'years'
+                is_period_size_independent = True
+                set_input = set_input_dispatch_by_period
+
+                def formula(individu, period):
+                    age = individu('age', period.first_month)
+                    return min_(age, 100)
+
+            self.add_variable(age_calage)
+    scenario_for_calibration = variables_pour_calibration(survey_scenario)
+    return scenario_for_calibration

--- a/tests/test_calage.py
+++ b/tests/test_calage.py
@@ -1,0 +1,47 @@
+import os
+
+import pytest
+
+from openfisca_survey_manager.calibration import Calibration  # type: ignore
+from openfisca_france_data import openfisca_france_data_location
+from openfisca_france_data.model.calage import create_dic_calage
+from openfisca_france_data.reforms.variables_calibration import create_calibration_tax_benefit_system
+from openfisca_france_data.erfs_fpr.scenario import (  # type: ignore
+    ErfsFprSurveyScenario,
+    )
+from openfisca_france_data import france_data_tax_benefit_system
+
+@pytest.fixture
+def location() -> str:
+    return openfisca_france_data_location
+
+
+def test_calage(survey_scenario, fake_input_data, location, year: int = 2015):
+    # On ititialise le survey scenario
+    survey_scenario2 = ErfsFprSurveyScenario.create(
+    tax_benefit_system = create_calibration_tax_benefit_system(france_data_tax_benefit_system),
+    period = year,
+    )
+    survey_scenario = survey_scenario2
+
+    # On charge les données
+    input_data = fake_input_data(year)
+
+    # On fait la calibration
+    parameters = dict(
+        method = "logit",
+        invlo = 3,
+        up = 3,
+        )
+
+    base_year = 2013
+
+    target_margins_by_variable = create_dic_calage(year, base_year, ["age"])
+
+    calibration_kwargs = {'target_margins_by_variable': target_margins_by_variable, 'parameters': parameters}
+
+    # On initialise le survey scenario
+    survey_scenario.init_from_data(data = dict(input_data_frame = input_data), calibration_kwargs = calibration_kwargs)
+    weight_base = sum(survey_scenario.calculate_variable("wprm", period = base_year))
+
+    assert weight_base < sum(survey_scenario.calculate_variable("wprm", period = year))


### PR DESCRIPTION
#### New features

L'objectif est de créer une banque de variables sur lesquelles caler des survey_scenario français. Concrètement, il s'agit de préparer un dictionnaire associant les variables à leurs cibles et utilisé ensuite dans les `calibration_kwargs`. 

Pour cela, cette PR : 
- Récupère des agrégats dans `assets/aggregats`
- Crée certaines variables spécifiques au calage dans `reforms/variables_calibration`
- Crée une fonction permettant de choisir les variables à caler parmi celles implémentées dans `model/calage` (il est facile d'en rajouter certaines supplémentaires an aval)
- Crée un test concernant ce calage dans `tests/test_calage` (celui-ci ne tourne qu'avec une modification d'OF-survey-manager)

Un obstacle à des variables de calage commun concerne les différence de champs entre données initiales (France, métropole, ménages ordinaires...). Pour prendre cela en compte, l'idée est de procéder par taux de variation entre la date des données et la date de simulation (en prenant pour cible le nombre de personnes de 3 ans en 2018 dans la base initiale * la variation du nombre d'enfant de cet âge entre 2018 et 2024 dans les agrégats pour une simulation de 2024 sur données 2018 par exemple). L'hypothèse est donc que les proportions évoluent de manière similaire selon le champs. 

Pour simplifier les mises à jour, l'idéal serait de mettre des données assez brutes dans les agrégats, pour pouvoir facilement en mettre de nouvelles. J'ai cependant dû déjà un peu modifier les projections de population par âge, qui me sert de test.