### PR TITLE
Maj cibles ines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 3.8.4 [#282](https://github.com/openfisca/openfisca-france-data/pull/282)
+
+* New features
+
+- Ajoute les agrégats des cibles budgétaires du modèle de microsimulation INES pour l'année 2023. Les aggrégats ont été récupérés dans le dépôt public d'ines :  https://gitlab.com/insee_drees_cnaf/ines-public/-/blob/main/parametres/Cibles_Ines.xlsx?ref_type=heads
+
 ### 3.8.3 [#278](https://github.com/openfisca/openfisca-france-data/pull/278)
 
 * New features

--- a/openfisca_france_data/assets/aggregats/ines/ines_2023.json
+++ b/openfisca_france_data/assets/aggregats/ines/ines_2023.json
@@ -1,5 +1,5 @@
 {
-    "documentation":"Pour les prestations sociales, les cotisations et prélèvements sociaux, note de validation INES 2022",
+    "documentation":"Agrégats issus des cibles budgétaires d'INES pour 2023, disponible dans le dépôt public du projet",
     "data":[
         {
             "variable":"af",
@@ -146,8 +146,7 @@
         {
             "variable":"prelevement_forfaitaire_liberatoire",
             "actual_beneficiaries":0,
-            "actual_amount":0,
-            "notes":"prélèvement forfaitaire libératoire sur revenus 2019 (note 2019)"
+            "actual_amount":0
         },
         {
             "variable":"ifi",

--- a/openfisca_france_data/assets/aggregats/ines/ines_2023.json
+++ b/openfisca_france_data/assets/aggregats/ines/ines_2023.json
@@ -94,7 +94,7 @@
         {
             "variable":"cotisations_employeur",
             "actual_beneficiaries":0,
-            "actual_amount":256794
+            "actual_amount":256794000000
         },
         {
             "variable":"allegement_general",

--- a/openfisca_france_data/assets/aggregats/ines/ines_2023.json
+++ b/openfisca_france_data/assets/aggregats/ines/ines_2023.json
@@ -1,0 +1,158 @@
+{
+    "documentation":"Pour les prestations sociales, les cotisations et prélèvements sociaux, note de validation INES 2022",
+    "data":[
+        {
+            "variable":"af",
+                "actual_beneficiaries": 5010000,
+                "actual_amount": 12644000000
+        },
+        {
+            "variable":"paje_prepare",
+            "actual_beneficiaries": 367000,
+            "actual_amount": 72000000
+        },
+        {
+            "variable":"aeeh",
+            "actual_beneficiaries": 400000,
+            "actual_amount": 1337000000
+        },
+        {
+            "variable":"asf",
+            "actual_beneficiaries": 0,
+            "actual_amount": 0
+        },
+        {
+            "variable":"paje_base",
+            "actual_beneficiaries": 1745000,
+            "actual_amount": 2783000000
+        },
+        {
+            "variable":"paje_naissance",
+            "actual_beneficiaries": 450000,
+            "actual_amount": 467000000
+        },
+        {
+            "variable":"cf",
+            "actual_beneficiaries": 963000,
+            "actual_amount":2313000000
+        },
+        {
+            "variable":"ars",
+            "actual_beneficiaries": 2732000,
+            "actual_amount": 1970000000
+        },
+        {
+            "variable":"paje_cmg",
+            "actual_beneficiaries": 1100000,
+            "actual_amount":6600000000
+        },
+        {
+            "variable":"aides_logement",
+            "actual_beneficiaries": 7000000,
+            "actual_amount": 136000000000
+        },
+        {
+            "variable":"aah",
+            "actual_beneficiaries": 1200000,
+            "actual_amount":9900000000
+        },
+        {
+            "variable":"aspa",
+            "actual_beneficiaries":500000,
+            "actual_amount": 2700000000
+        },
+        {
+            "variable":"asi",
+            "actual_beneficiaries":0,
+            "actual_amount":0
+        },
+        {
+            "variable":"garantie_jeunes",
+            "actual_beneficiaries": 0,
+            "actual_amount":0
+        },
+        {
+            "variable":"rsa",
+            "actual_beneficiaries": 2300000,
+            "actual_amount":9400000000
+        },
+        {
+            "variable":"ppa",
+            "actual_beneficiaries": 6300000,
+            "actual_amount": 9200000000
+        },
+        {
+            "variable":"cotisations_salariales",
+            "actual_beneficiaries":0,
+            "actual_amount": 87500000000
+        },
+        {
+            "variable":"cotisations_non_salarie",
+            "actual_beneficiaries":0,
+            "actual_amount":0
+        },
+        {
+            "variable":"cotisations_employeur",
+            "actual_beneficiaries":0,
+            "actual_amount":245100000000
+        },
+        {
+            "variable":"allegement_general",
+            "actual_beneficiaries":0,
+            "actual_amount":34200000000
+        },
+        {
+            "variable":"csg_salaire",
+            "actual_beneficiaries":0,
+            "actual_amount":83100000000
+        },
+        {
+            "variable":"csg_non_salarie",
+            "actual_beneficiaries":0,
+            "actual_amount":12600000000
+        },
+        {
+            "variable":"csg_remplacement",
+            "actual_beneficiaries":0,
+            "actual_amount":23300000000
+        },
+        {
+            "variable":"crds_salaire",
+            "actual_beneficiaries":0,
+            "actual_amount":4500000000
+        },
+        {
+            "variable":"crds_non_salarie",
+            "actual_beneficiaries":0,
+            "actual_amount":700000000
+        },
+        {
+            "variable":"crds_remplacement",
+            "actual_beneficiaries":0,
+            "actual_amount":18000000000
+        },
+        {
+            "variable":"impot_revenu_restant_a_payer",
+            "actual_beneficiaries":0,
+            "actual_amount":72600000000,
+            "notes":"Impot payé en 2021, en parti sur revenus 2021 et 2020"
+        },
+        {
+            "variable":"prelevement_forfaitaire_unique_ir",
+            "actual_beneficiaries":0,
+            "actual_amount":0,
+            "notes":"prélèvement forfaitaire unique libératoire sur revenus 2019 (note 2020)"
+        },
+        {
+            "variable":"prelevement_forfaitaire_liberatoire",
+            "actual_beneficiaries":0,
+            "actual_amount":0,
+            "notes":"prélèvement forfaitaire libératoire sur revenus 2019 (note 2019)"
+        },
+        {
+            "variable":"ifi",
+            "actual_beneficiaries":0,
+            "actual_amount":0
+        }
+    ]
+}

--- a/openfisca_france_data/assets/aggregats/ines/ines_2023.json
+++ b/openfisca_france_data/assets/aggregats/ines/ines_2023.json
@@ -44,27 +44,27 @@
         {
             "variable":"paje_cmg",
             "actual_beneficiaries": 1100000,
-            "actual_amount":6600000000
+            "actual_amount":6878000000
         },
         {
             "variable":"aides_logement",
-            "actual_beneficiaries": 7000000,
-            "actual_amount": 136000000000
+            "actual_beneficiaries": 6643000,
+            "actual_amount": 135720000000
         },
         {
             "variable":"aah",
-            "actual_beneficiaries": 1200000,
-            "actual_amount":9900000000
+            "actual_beneficiaries": 1467000,
+            "actual_amount":10762000000
         },
         {
             "variable":"aspa",
-            "actual_beneficiaries":500000,
-            "actual_amount": 2700000000
+            "actual_beneficiaries":528000,
+            "actual_amount": 2916000000
         },
         {
             "variable":"asi",
-            "actual_beneficiaries":0,
-            "actual_amount":0
+            "actual_beneficiaries":57000,
+            "actual_amount":248000000
         },
         {
             "variable":"garantie_jeunes",
@@ -73,75 +73,75 @@
         },
         {
             "variable":"rsa",
-            "actual_beneficiaries": 2300000,
-            "actual_amount":9400000000
+            "actual_beneficiaries": 2182000,
+            "actual_amount":9511000000
         },
         {
             "variable":"ppa",
-            "actual_beneficiaries": 6300000,
-            "actual_amount": 9200000000
+            "actual_beneficiaries": 6219000,
+            "actual_amount": 9612000000
         },
         {
             "variable":"cotisations_salariales",
             "actual_beneficiaries":0,
-            "actual_amount": 87500000000
+            "actual_amount": 92322000000
         },
         {
             "variable":"cotisations_non_salarie",
             "actual_beneficiaries":0,
-            "actual_amount":0
+            "actual_amount":26442000000
         },
         {
             "variable":"cotisations_employeur",
             "actual_beneficiaries":0,
-            "actual_amount":245100000000
+            "actual_amount":256794
         },
         {
             "variable":"allegement_general",
             "actual_beneficiaries":0,
-            "actual_amount":34200000000
+            "actual_amount":37764000000
         },
         {
             "variable":"csg_salaire",
             "actual_beneficiaries":0,
-            "actual_amount":83100000000
+            "actual_amount":87627000000
         },
         {
             "variable":"csg_non_salarie",
             "actual_beneficiaries":0,
-            "actual_amount":12600000000
+            "actual_amount":12351000000
         },
         {
             "variable":"csg_remplacement",
             "actual_beneficiaries":0,
-            "actual_amount":23300000000
+            "actual_amount":24461000000
         },
         {
             "variable":"crds_salaire",
             "actual_beneficiaries":0,
-            "actual_amount":4500000000
+            "actual_amount":4756000000
         },
         {
             "variable":"crds_non_salarie",
             "actual_beneficiaries":0,
-            "actual_amount":700000000
+            "actual_amount":678000000
         },
         {
             "variable":"crds_remplacement",
             "actual_beneficiaries":0,
-            "actual_amount":18000000000
+            "actual_amount":1973000000
         },
         {
             "variable":"impot_revenu_restant_a_payer",
             "actual_beneficiaries":0,
-            "actual_amount":72600000000,
-            "notes":"Impot payé en 2021, en parti sur revenus 2021 et 2020"
+            "actual_amount":90211000000,
+            "notes":"Notion pas très clair, d'après dgfip montant net = 81547000000 pour la France métropolitaine"
         },
         {
             "variable":"prelevement_forfaitaire_unique_ir",
             "actual_beneficiaries":0,
-            "actual_amount":0,
-            "notes":"prélèvement forfaitaire unique libératoire sur revenus 2019 (note 2020)"
+            "actual_amount":7380000000,
+            "notes":"prélèvement forfaitaire unique libératoire sur revenus 2023 + revenus 2022 - CI sur PFO N-1"
         },
         {
             "variable":"prelevement_forfaitaire_liberatoire",
@@ -152,7 +152,7 @@
         {
             "variable":"ifi",
             "actual_beneficiaries":0,
-            "actual_amount":0
+            "actual_amount":1880000000
         }
     ]
 }

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setup(
     name = "OpenFisca-France-Data",
-    version = "3.8.3",
+    version = "3.8.4",
     description = "OpenFisca-France-Data module to work with French survey data",
     long_description = long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### New features

- Ajoute les agrégats des cibles budgétaires du modèle de microsimulation INES pour l'année 2023. Les aggrégats ont été récupérés dans le dépôt public d'ines :  https://gitlab.com/insee_drees_cnaf/ines-public/-/blob/main/parametres/Cibles_Ines.xlsx?ref_type=heads
